### PR TITLE
build: use datadir in define_variable for dbus_services_dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ pkg = import('pkgconfig')
 i18n = import('i18n')
 
 dbus_services_dir = dependency('dbus-1').get_pkgconfig_variable('session_bus_services_dir',
-                                                                define_variable: ['prefix', get_option('prefix')])
+                                                                define_variable: ['datadir', get_option('datadir')])
 libexec_path = join_paths(get_option('prefix'), get_option('libexecdir'), 'xapps', 'sn-watcher')
 
 cdata = configuration_data()


### PR DESCRIPTION
We have to use datadir to effect dbus-1.pc https://github.com/freedesktop/dbus/blob/b387bd4d2916416f1376fe9feeee61e557d571de/dbus-1.pc.in#L11