### PR TITLE
xfce4-set-wallpaper: resolve relative path

### DIFF
--- a/scripts/xfce4-set-wallpaper
+++ b/scripts/xfce4-set-wallpaper
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # Author: Weitian Leung <weitianleung@gmail.com>
-# Version: 2.0
+# Version: 2.1
 # License: GPL-3.0
 # Description: set a picture as xfce4 wallpaper
 
-wallpaper=$1
+# xfce4-desktop requires an absolute path.
+wallpaper="$(realpath "$1")"
 
 # check image
 mime_type=`file --mime-type -b "$wallpaper"`


### PR DESCRIPTION
Hi, there is an error in `xfce4-set-wallpaper` script: `xfce4-desktop` requires an absolute path to show the wallpaper, but the script doesn't do any check. So if the user run the script with a relative path, like `xfce4-set-wallpaper my-background.png` it fails to set correctly the wallpaper.

I fixed using `realpath` to obtain the absolute path, it is installed by default on Fedora 32, but I am not sure on other operating systems. Another option is to use `readlink`, but it may be not installed.