### PR TITLE
fix xorg-server startup variable

### DIFF
--- a/data/80xapp-gtk3-module.sh
+++ b/data/80xapp-gtk3-module.sh
@@ -1,4 +1,4 @@
-# This file is sourced by Xsession(5), not executed.
+# This file is sourced by xinit(1) or a display manager's Xsession, not executed.
 
 if [ -z "$GTK_MODULES" ] ; then
     GTK_MODULES="xapp-gtk3-module"

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,3 @@
-install_data(['80xapp-gtk3-module'],
-  install_dir: join_paths(get_option('sysconfdir'), 'X11', 'Xsession.d')
+install_data(['80xapp-gtk3-module.sh'],
+  install_dir: join_paths(get_option('sysconfdir'), 'X11', 'xinit', 'xinitrc.d')
 )


### PR DESCRIPTION
Xsession is something specific to e.g. GDM or lightdm, which in turn sources all shell scripts in /etc/X11/xinit/xinitrc.d

Meanwhile the standard xorg-xinit provided xinitrc also sources the scripts in /etc/X11/xinit/xinitrc.d

/etc/X11/Xsession.d works absolutely nowhere other than Debian, and Debian will eventually load the standard /etc/X11/xinit/xinitrc.d directory via sourcing .xinitrc anyway; hence moving this file to the standard location will result in this working as intended everywhere.