### PR TITLE
Add shebang to 80xapp-gtk3-module.sh

### DIFF
--- a/data/80xapp-gtk3-module.sh
+++ b/data/80xapp-gtk3-module.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/bash
 # This file is sourced by xinit(1) or a display manager's Xsession, not executed.
 
 if [ -z "$GTK_MODULES" ] ; then


### PR DESCRIPTION
rpm strips the executable perms if there is no shebang.

+ /usr/lib/rpm/redhat/brp-mangle-shebangs
mangling shebang in /usr/bin/xfce4-set-wallpaper from /bin/bash to #!/usr/bin/bash
*** WARNING: ./etc/X11/xinit/xinitrc.d/80xapp-gtk3-module.sh is executable but has no shebang, removing executable bit
Processing files: xapps-2.0.1-2.fc33.x86_64