### PR TITLE
Change shebang path

### DIFF
--- a/data/80xapp-gtk3-module.sh
+++ b/data/80xapp-gtk3-module.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # This file is sourced by xinit(1) or a display manager's Xsession, not executed.
 
 if [ -z "$GTK_MODULES" ] ; then


### PR DESCRIPTION
Change shebang pathm ubuntu, debian and mandriva use /bin/bash.

Fixes #123 