### PR TITLE
Use GTK3_MODULES since gtk2 isn't supported.

### DIFF
--- a/data/80xapp-gtk3-module.sh
+++ b/data/80xapp-gtk3-module.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # This file is sourced by xinit(1) or a display manager's Xsession, not executed.
 
-if [ -z "$GTK_MODULES" ] ; then
-    GTK_MODULES="xapp-gtk3-module"
+if [ -z "$GTK3_MODULES" ] ; then
+    GTK3_MODULES="xapp-gtk3-module"
 else
-    GTK_MODULES="$GTK_MODULES:xapp-gtk3-module"
+    GTK3_MODULES="$GTK3_MODULES:xapp-gtk3-module"
 fi
 
-export GTK_MODULES
+export GTK3_MODULES


### PR DESCRIPTION
xapp only provides a module for gtk3, so use `GTK3_MODULES` instead of `GTK_MODULES`.
https://developer.gnome.org/gtk3/stable/gtk-running.html

This stops gtk2 apps from complaining about missing modules.
```
Gtk-Message: 03:44:21.139: Failed to load module "xapp-gtk3-module"
```