### PR TITLE
util: add a utility function to convert from a pango font string to css

### DIFF
--- a/libxapp/xapp-style-manager.c
+++ b/libxapp/xapp-style-manager.c
@@ -1,4 +1,5 @@
 #include "xapp-style-manager.h"
+#include "xapp-util.h"
 
 /**
  * SECTION:xapp-style-manager
@@ -253,4 +254,23 @@ xapp_style_manager_remove_style_property (XAppStyleManager *style_manager,
     g_hash_table_remove (style_manager->properties, name);
 
     process_property_list_update (style_manager);
+}
+
+/**
+ * xapp_style_manager_set_from_pango_font_string:
+ * @style_manager: a #XAppStyleManager
+ * @desc_string: a pango font description string
+ *
+ * Sets the css font property on the widget based on the supplied pango font description string.
+ *
+ * Since: 2.2
+ */
+void
+xapp_style_manager_set_from_pango_font_string (XAppStyleManager *style_manager,
+                                                     const gchar      *desc_string)
+{
+    gchar *css_string = xapp_pango_font_string_to_css (desc_string);
+
+    xapp_style_manager_set_style_property (style_manager, "font", css_string);
+    g_free (css_string);
 }

--- a/libxapp/xapp-style-manager.h
+++ b/libxapp/xapp-style-manager.h
@@ -19,6 +19,9 @@ void               xapp_style_manager_set_style_property    (XAppStyleManager *s
 void               xapp_style_manager_remove_style_property (XAppStyleManager *style_manager,
                                                              const gchar      *name);
 
+void               xapp_style_manager_set_from_pango_font_string (XAppStyleManager *style_manager,
+                                                                  const gchar      *desc_string);
+
 G_END_DECLS
 
 #endif  /* __XAPP_STYLE_MANAGER_H__  */

--- a/libxapp/xapp-util.c
+++ b/libxapp/xapp-util.c
@@ -3,6 +3,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <pango/pango.h>
 
 #include "xapp-util.h"
 
@@ -103,4 +104,144 @@ xapp_util_get_session_is_running (void)
     g_object_unref (session_bus);
 
     return session_running;
+}
+
+/**
+ * xapp_pango_font_string_to_css:
+ * @pango_font_string: a pango font description string
+ *
+ * Converts a pango font description string to a string suitable for use with the css "font" tag. The font description must contain the font family and font size or conversion will fail and %NULL will be returned
+ *
+ * Returns: (transfer full) the css compatible font string or %NULL if the conversion failed.
+ *
+ * Since: 2.2
+ */
+gchar *
+xapp_pango_font_string_to_css (const char *pango_font_string)
+{
+    PangoFontDescription *desc;
+    GString *font_string;
+    PangoFontMask set;
+
+    desc = pango_font_description_from_string (pango_font_string);
+    font_string = g_string_new ("");
+
+    set = pango_font_description_get_set_fields (desc);
+
+    if (!(set & PANGO_FONT_MASK_SIZE) || !(set & PANGO_FONT_MASK_FAMILY))
+    {
+        return NULL;
+    }
+
+    if (set & PANGO_FONT_MASK_STYLE)
+    {
+        switch (pango_font_description_get_style (desc))
+        {
+            case PANGO_STYLE_NORMAL:
+                g_string_append (font_string, "normal ");
+                break;
+            case PANGO_STYLE_OBLIQUE:
+                g_string_append (font_string, "oblique ");
+                break;
+            case PANGO_STYLE_ITALIC:
+                g_string_append (font_string, "italic ");
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (set & PANGO_FONT_MASK_VARIANT)
+    {
+        switch (pango_font_description_get_variant (desc))
+        {
+            case PANGO_VARIANT_NORMAL:
+                g_string_append (font_string, "normal ");
+                break;
+            case PANGO_VARIANT_SMALL_CAPS:
+                g_string_append (font_string, "small-caps ");
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (set & PANGO_FONT_MASK_WEIGHT)
+    {
+        switch (pango_font_description_get_weight (desc))
+        {
+            case PANGO_WEIGHT_THIN:
+                g_string_append (font_string, "100 ");
+                break;
+            case PANGO_WEIGHT_ULTRALIGHT:
+                g_string_append (font_string, "200 ");
+                break;
+            case PANGO_WEIGHT_LIGHT:
+            case PANGO_WEIGHT_SEMILIGHT:
+                g_string_append (font_string, "300 ");
+                break;
+            case PANGO_WEIGHT_BOOK:
+            case PANGO_WEIGHT_NORMAL:
+                g_string_append (font_string, "400 ");
+                break;
+            case PANGO_WEIGHT_MEDIUM:
+                g_string_append (font_string, "500 ");
+                break;
+            case PANGO_WEIGHT_SEMIBOLD:
+                g_string_append (font_string, "600 ");
+                break;
+            case PANGO_WEIGHT_BOLD:
+                g_string_append (font_string, "700 ");
+                break;
+            case PANGO_WEIGHT_ULTRABOLD:
+                g_string_append (font_string, "800 ");
+                break;
+            case PANGO_WEIGHT_HEAVY:
+            case PANGO_WEIGHT_ULTRAHEAVY:
+                g_string_append (font_string, "900 ");
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (set & PANGO_FONT_MASK_STRETCH)
+    {
+        switch (pango_font_description_get_stretch (desc))
+        {
+            case PANGO_STRETCH_ULTRA_CONDENSED:
+                g_string_append (font_string, "ultra-condensed ");
+                break;
+            case PANGO_STRETCH_EXTRA_CONDENSED:
+                g_string_append (font_string, "extra-condensed ");
+                break;
+            case PANGO_STRETCH_CONDENSED:
+                g_string_append (font_string, "condensed ");
+                break;
+            case PANGO_STRETCH_SEMI_CONDENSED:
+                g_string_append (font_string, "semi-condensed ");
+                break;
+            case PANGO_STRETCH_NORMAL:
+                g_string_append (font_string, "normal ");
+                break;
+            case PANGO_STRETCH_SEMI_EXPANDED:
+                g_string_append (font_string, "semi-expanded ");
+                break;
+            case PANGO_STRETCH_EXPANDED:
+                g_string_append (font_string, "expanded ");
+                break;
+            case PANGO_STRETCH_EXTRA_EXPANDED:
+                break;
+            case PANGO_STRETCH_ULTRA_EXPANDED:
+                g_string_append (font_string, "ultra-expanded ");
+                break;
+            default:
+                break;
+        }
+    }
+
+    g_string_append_printf (font_string, "%dpx ", pango_font_description_get_size (desc) / PANGO_SCALE);
+    g_string_append (font_string, pango_font_description_get_family (desc));
+
+    return g_string_free (font_string, FALSE);
 }

--- a/libxapp/xapp-util.h
+++ b/libxapp/xapp-util.h
@@ -8,5 +8,8 @@ G_BEGIN_DECLS
 gboolean xapp_util_gpu_offload_supported (void);
 gboolean xapp_util_get_session_is_running (void);
 
+gchar *xapp_pango_font_string_to_css (const char *pango_font_string);
+
+
 G_END_DECLS
 #endif /* __XAPP_UTIL_H__ */


### PR DESCRIPTION
Also adds a convenience method to the style manager.