### PR TITLE
meson gir: Export 'xapp' as a package

### DIFF
--- a/libxapp/meson.build
+++ b/libxapp/meson.build
@@ -129,6 +129,7 @@ gir = gnome.generate_gir(libxapp,
     sources: xapp_headers + xapp_sources + dbus_headers + xapp_enums,
     identifier_prefix: 'XApp',
     symbol_prefix: 'xapp_',
+    export_packages: 'xapp',
     includes: ['GObject-2.0', 'Gtk-3.0'],
     install: true
 )


### PR DESCRIPTION
This caused an issue where a package tag wouldn't generate. This could
cause problems with other tools, such as gtk-rs's rust binding generation
tool.

Closes #141