### PR TITLE
xapp-gtk3-module.c: Apply window icon override to all windows for an app

### DIFF
--- a/libxapp/xapp-gtk3-module.c
+++ b/libxapp/xapp-gtk3-module.c
@@ -98,13 +98,12 @@ overridden_window_realize (GtkWidget *widget)
 {
     (* original_window_realize) (widget);
 
-    static gint already_applied = 0;
-    if (already_applied)
+    if (g_object_get_data (G_OBJECT (widget), "xapp-module-window-seen"))
     {
         return;
     }
 
-    already_applied = 1;
+    g_object_set_data (G_OBJECT (widget), "xapp-module-window-seen", GINT_TO_POINTER (1));
 
     DEBUG ("Realize overridden window (%p).", widget);
 


### PR DESCRIPTION
Firefox 92 creates and destroys multiple windows at startup, but
this module was only overriding the icon for the initial one.

This has a potential impact for additional windows opened by
the user deliberately (right-click an external link and open
in new window) - these windows will end up with the same icon.

Fixes #145