### PR TITLE
libxapp: add missing gio-unix-2.0 dependency

### DIFF
--- a/libxapp/meson.build
+++ b/libxapp/meson.build
@@ -1,11 +1,13 @@
 glib_min_ver = '>=2.44.0'
 
 gio_dep = dependency('gio-2.0', version: glib_min_ver, required: true)
+gio_unix_dep = dependency('gio-unix-2.0', version: glib_min_ver, required: true)
 glib_dep = dependency('glib-2.0', version: glib_min_ver, required: true)
 gtk3_dep = dependency('gtk+-3.0', version: '>=3.16', required: true)
 
 libdeps = []
 libdeps += gio_dep
+libdeps += gio_unix_dep
 libdeps += glib_dep
 libdeps += gtk3_dep
 libdeps += dependency('gdk-pixbuf-2.0', version: '>=2.22.0', required: true)


### PR DESCRIPTION
The Nix package manager used by NixOS (and available on all unix systems), uses a sandboxed environment where it is not possible to have global building dependencies. Without this change the build with fails with:

```
[68/100] Compiling C object xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-item-interface.c.o
FAILED: xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-item-interface.c.o 
gcc -Ixapp-sn-watcher/xapp-sn-watcher.p -Ixapp-sn-watcher -I../xapp-sn-watcher -I. -I.. -Ilibxapp -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/8v00frlpafiyirny6pgwgf1d99l46vci-libgnomekbd-3.26.1-dev/include -I/nix/store/80i5li0nc4glw3c1b0y0l0dqi2k9j26b-libxklavier-5.4-dev/include -I/nix/store/7yrsavfnaiqjab655mm8vyg5daxf02zq-libdbusmenu-gtk3-16.04.0/include/libdbusmenu-gtk3-0.4 -I/nix/store/7yrsavfnaiqjab655mm8vyg5daxf02zq-libdbusmenu-gtk3-16.04.0/include/libdbusmenu-glib-0.4 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wunused -Wimplicit-function-declaration -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -pthread -MD -MQ xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-item-interface.c.o -MF xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-item-interface.c.o.d -o xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-item-interface.c.o -c xapp-sn-watcher/sn-item-interface.c
xapp-sn-watcher/sn-item-interface.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
[69/100] Generating status-applets/mate/org.x.MateXAppStatusApplet.mate-panel-applet with a custom command
[70/100] Compiling C object xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-watcher-interface.c.o
FAILED: xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-watcher-interface.c.o 
gcc -Ixapp-sn-watcher/xapp-sn-watcher.p -Ixapp-sn-watcher -I../xapp-sn-watcher -I. -I.. -Ilibxapp -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/8v00frlpafiyirny6pgwgf1d99l46vci-libgnomekbd-3.26.1-dev/include -I/nix/store/80i5li0nc4glw3c1b0y0l0dqi2k9j26b-libxklavier-5.4-dev/include -I/nix/store/7yrsavfnaiqjab655mm8vyg5daxf02zq-libdbusmenu-gtk3-16.04.0/include/libdbusmenu-gtk3-0.4 -I/nix/store/7yrsavfnaiqjab655mm8vyg5daxf02zq-libdbusmenu-gtk3-16.04.0/include/libdbusmenu-glib-0.4 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wunused -Wimplicit-function-declaration -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -pthread -MD -MQ xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-watcher-interface.c.o -MF xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-watcher-interface.c.o.d -o xapp-sn-watcher/xapp-sn-watcher.p/meson-generated_.._sn-watcher-interface.c.o -c xapp-sn-watcher/sn-watcher-interface.c
xapp-sn-watcher/sn-watcher-interface.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
[71/100] Compiling C object libxapp/libxapp.so.2.2.13.p/meson-generated_.._xapp-statusicon-interface.c.o
FAILED: libxapp/libxapp.so.2.2.13.p/meson-generated_.._xapp-statusicon-interface.c.o 
gcc -Ilibxapp/libxapp.so.2.2.13.p -Ilibxapp -I../libxapp -I. -I.. -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/8v00frlpafiyirny6pgwgf1d99l46vci-libgnomekbd-3.26.1-dev/include -I/nix/store/80i5li0nc4glw3c1b0y0l0dqi2k9j26b-libxklavier-5.4-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wunused -Wimplicit-function-declaration -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -fPIC -pthread -Wno-declaration-after-statement '-DG_LOG_DOMAIN="XApp"' -MD -MQ libxapp/libxapp.so.2.2.13.p/meson-generated_.._xapp-statusicon-interface.c.o -MF libxapp/libxapp.so.2.2.13.p/meson-generated_.._xapp-statusicon-interface.c.o.d -o libxapp/libxapp.so.2.2.13.p/meson-generated_.._xapp-statusicon-interface.c.o -c libxapp/xapp-statusicon-interface.c
libxapp/xapp-statusicon-interface.c:17:12: fatal error: gio/gunixfdlist.h: No such file or directory
   17 | #  include <gio/gunixfdlist.h>
      |            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
[72/100] Compiling C object libxapp/libxapp-gtk3-module.so.p/xapp-gtk3-module.c.o
[73/100] Compiling C object xapp-sn-watcher/xapp-sn-watcher.p/xapp-sn-watcher.c.o
[74/100] Generating libxapp/xapp-enums.c with a custom command (wrapped by meson to capture output)
[75/100] Compiling C object xapp-sn-watcher/xapp-sn-watcher.p/sn-item.c.o
ninja: build stopped: subcommand failed.
```

See also 

- https://github.com/NixOS/nixpkgs/issues/36468

Thanks for reviewing this :-)