### PR TITLE
Fix meson.build deprecations up to 0.56.0

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -3,8 +3,8 @@ subdir('xml')
 gnome.gtkdoc('libxapp',
     install: true,
     src_dir: [
-        join_paths(meson.source_root(), 'libxapp'),
-        join_paths(meson.build_root(), 'libxapp'),
+        join_paths(meson.project_source_root(), 'libxapp'),
+        join_paths(meson.project_build_root(), 'libxapp'),
     ],
     dependencies: libxapp_dep,
     gobject_typesfile: 'libxapp.types',

--- a/libxapp/meson.build
+++ b/libxapp/meson.build
@@ -157,6 +157,6 @@ if not app_lib_only
         include_directories: [top_inc],
         dependencies: [gtk3_dep, libxapp_dep],
         install: true,
-        install_dir: join_paths(gtk3_dep.get_pkgconfig_variable('libdir'),'gtk-3.0','modules')
+        install_dir: join_paths(gtk3_dep.get_variable(pkgconfig: 'libdir'),'gtk-3.0','modules')
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -2,14 +2,15 @@ project('xapp',
     'c',
     version : '2.6.1',
     default_options : [ 'buildtype=debugoptimized' ],
+    meson_version : '>=0.56.0'
 )
 
 gnome = import('gnome')
 pkg = import('pkgconfig')
 i18n = import('i18n')
 
-dbus_services_dir = dependency('dbus-1').get_pkgconfig_variable('session_bus_services_dir',
-                                                                define_variable: ['datadir', get_option('datadir')])
+dbus_services_dir = dependency('dbus-1').get_variable(pkgconfig: 'session_bus_services_dir',
+                                                                pkgconfig_define: ['datadir', get_option('datadir')])
 sn_watcher_dir = join_paths(get_option('prefix'), get_option('libdir'), 'xapps')
 
 cdata = configuration_data()

--- a/status-applets/mate/meson.build
+++ b/status-applets/mate/meson.build
@@ -51,7 +51,7 @@ i18n.merge_file(
   input: def_file,
   output: 'org.x.MateXAppStatusApplet.mate-panel-applet',
   type: 'desktop',
-  po_dir: join_paths(meson.source_root(), 'po'),
+  po_dir: join_paths(meson.project_source_root(), 'po'),
   install: true,
   install_dir: join_paths(get_option('datadir'), 'mate-panel', 'applets')
 )


### PR DESCRIPTION
Similar to linuxmint/cinnamon#11870
Similar to linuxmint/cinnamon-control-center#318
Similar to linuxmint/cinnamon-desktop#234
Similar to linuxmint/cinnamon-menus#67
Similar to linuxmint/cinnamon-screensaver#444
Similar to linuxmint/cinnamon-session#155
Similar to linuxmint/cinnamon-settings-daemon#383
Similar to linuxmint/cjs#119
Similar to linuxmint/muffin#675
Similar to linuxmint/nemo#3316
Similar to linuxmint/nemo-extensions#496