### PR TITLE
 Improve discrete GPU detection using switcheroo-control

### DIFF
--- a/libxapp/xapp-gpu-offload-helper.c
+++ b/libxapp/xapp-gpu-offload-helper.c
@@ -183,7 +183,7 @@ process_gpus_property (XAppGpuOffloadHelper  *helper,
         }
 
         is_default = vdefault ? g_variant_get_boolean (vdefault) : FALSE;
-        is_discrete = vdefault ? g_variant_get_boolean (vdiscrete) : FALSE;
+        is_discrete = vdiscrete ? g_variant_get_boolean (vdiscrete) : FALSE;
 
         if (is_default)
         {

--- a/libxapp/xapp-gpu-offload-helper.h
+++ b/libxapp/xapp-gpu-offload-helper.h
@@ -26,6 +26,7 @@ struct _XAppGpuInfo
 {
     gint id;
     gboolean is_default;
+    gboolean is_discrete;
     gchar *display_name;
     gchar **env_strv;
 };


### PR DESCRIPTION
Adds proper discrete GPU detection through switcheroo-control.

Required switcheroo-control PR https://gitlab.freedesktop.org/hadess/switcheroo-control/-/merge_requests/69

KDE Counterpart: https://invent.kde.org/frameworks/kio/-/merge_requests/1556
GNOME Counterpart: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3193