### PR TITLE
Allow installing GObject Introspection overrides to multiple python installations

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,9 +9,14 @@ option('deprecated_warnings',
     description: 'Show build warnings for deprecations'
 )
 option('py-overrides-dir',
-    type : 'string',
-    value : '',
+    type : 'array',
+    value : [],
     description: 'Path to pygobject overrides directory'
+)
+option('python_target',
+    type: 'array',
+    value: ['python3'],
+    description: 'Python installation to target to lookup if py-overrides-dir not supplied'
 )
 option('status-notifier',
     type: 'boolean',

--- a/pygobject/meson.build
+++ b/pygobject/meson.build
@@ -3,22 +3,31 @@ pygobject = dependency('pygobject-3.0',
     required: true,
 )
 
-override_dir = get_option('py-overrides-dir')
+override_dirs = get_option('py-overrides-dir')
 
-if override_dir == ''
-    exec = find_program(['python3', 'python'])
+if override_dirs.length() == 0 or override_dirs[0] == ''
+    override_dirs = []
 
-    r = run_command(exec, '-c', 'import gi;print(gi._overridesdir)', check: false)
+    pymod = import('python')
+    python_targets = get_option('python_target')
 
-    if r.returncode() != 0
-         error('Error getting the GObject Introspection override directory: ' + r.stderr())
-    endif
+    foreach python_target : python_targets
+        python_install = pymod.find_installation(python_target)
 
-    override_dir = r.stdout().strip()
+        r = run_command(python_install, '-c', 'import gi;print(gi._overridesdir)', check: false)
+
+        if r.returncode() != 0
+            error('Error getting the GObject Introspection override directory: ' + r.stderr())
+        endif
+
+        override_dirs += r.stdout().strip()
+    endforeach
 endif
 
-message('PyGObject overrides dir: ' + override_dir)
+message('PyGObject overrides dirs: @0@'.format(override_dirs))
 
-install_data(['XApp.py'],
-    install_dir: override_dir,
-)
+foreach override_dir : override_dirs
+    install_data(['XApp.py'],
+        install_dir: override_dir,
+    )
+endforeach


### PR DESCRIPTION
Allow installing GObject Introspection overrides to multiple system python installations. This is something Gentoo supports (I'm not sure about other distros) so this has made packaging a little messy.

Switching `py-overrides-dir` to `array` allows for passing multiple paths as a comma separated string, and should maintain compatibility with existing build harnesses.

This also switches from `find_program` to `python.find_installation` and adds a `python_target` to allow specifying multiple installation targets instead of a list of paths. I defaulted `python_target` to just `python3`, as I assume `python` and `python3` refer to the same python installation on modern systems. This also matches the default for `python3-xapp`.

```
meson setup ... -Dpython_target=python3.11,python3.12 ...
```
```
Message: PyGObject overrides dirs: ['/usr/lib/python3.11/site-packages/gi/overrides', '/usr/lib/python3.12/site-packages/gi/overrides']
```